### PR TITLE
Migrate to Swift 4.2

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/PureSwift/CCairo.git",
         "state": {
           "branch": null,
-          "revision": "1bd46ac81056766182be22fccc2cdf0e457f042f",
-          "version": "1.1.1"
+          "revision": "2051a137b52995d7795c0dc9c08cd2ea2a2b570c",
+          "version": null
         }
       },
       {
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/PureSwift/CFontConfig.git",
         "state": {
           "branch": null,
-          "revision": "e5bae817dbd1eb402f395d960485c52350b2bd88",
-          "version": "1.0.1"
+          "revision": "f47c3ea87307478428df762dc2e181c12643a884",
+          "version": null
         }
       },
       {
@@ -24,8 +24,8 @@
         "repositoryURL": "https://github.com/PureSwift/CFreeType.git",
         "state": {
           "branch": null,
-          "revision": "079909dc68c13c700bb6bab3059ddf51f642b43a",
-          "version": "1.0.4"
+          "revision": "a8c830218999af31691e154cecae783bae1f0ab9",
+          "version": null
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -5,13 +5,13 @@ import PackageDescription
 
 let package = Package(
     name: "Cairo",
+    products: [
+        .library(name: "Cairo", targets: ["Cairo"])
+    ],
     dependencies: [
         .package(url: "https://github.com/PureSwift/CCairo.git", .revision("2051a137b52995d7795c0dc9c08cd2ea2a2b570c")),
         .package(url: "https://github.com/PureSwift/CFontConfig.git", .revision("f47c3ea87307478428df762dc2e181c12643a884")),
         .package(url: "https://github.com/PureSwift/CFreeType.git", .revision("a8c830218999af31691e154cecae783bae1f0ab9"))
-    ],
-    products: [
-        .library(name: "Cairo", targets: ["Cairo"])
     ],
     targets: [
         .target(

--- a/Package.swift
+++ b/Package.swift
@@ -10,6 +10,9 @@ let package = Package(
         .package(url: "https://github.com/PureSwift/CFontConfig.git", .revision("f47c3ea87307478428df762dc2e181c12643a884")),
         .package(url: "https://github.com/PureSwift/CFreeType.git", .revision("a8c830218999af31691e154cecae783bae1f0ab9"))
     ],
+    products: [
+        .library(name: "Cairo", targets: ["Cairo"])
+    ],
     targets: [
         .target(
             name: "Cairo",

--- a/Package.swift
+++ b/Package.swift
@@ -1,17 +1,18 @@
-// swift-tools-version:3.0.2
+// swift-tools-version:4.2
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
 
 let package = Package(
     name: "Cairo",
-    targets: [
-        Target(
-            name: "Cairo")
-    ],
     dependencies: [
-        .Package(url: "https://github.com/PureSwift/CCairo.git", majorVersion: 1),
-        .Package(url: "https://github.com/PureSwift/CFontConfig.git", majorVersion: 1),
-        .Package(url: "https://github.com/PureSwift/CFreeType.git", majorVersion: 1)
+        .package(url: "https://github.com/PureSwift/CCairo.git", from: "1.0.0"),
+        .package(url: "https://github.com/PureSwift/CFontConfig.git", from: "1.0.0"),
+        .package(url: "https://github.com/PureSwift/CFreeType.git", from: "1.0.0")
+    ],
+    targets: [
+        .target(
+            name: "Cairo"
+        )
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -12,7 +12,8 @@ let package = Package(
     ],
     targets: [
         .target(
-            name: "Cairo"
+            name: "Cairo",
+            dependencies: ["CCairo", "CFontConfig", "CFreeType"]
         )
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -6,9 +6,9 @@ import PackageDescription
 let package = Package(
     name: "Cairo",
     dependencies: [
-        .package(url: "https://github.com/PureSwift/CCairo.git", from: "1.0.0"),
-        .package(url: "https://github.com/PureSwift/CFontConfig.git", from: "1.0.0"),
-        .package(url: "https://github.com/PureSwift/CFreeType.git", from: "1.0.0")
+        .package(url: "https://github.com/PureSwift/CCairo.git", .revision("2051a137b52995d7795c0dc9c08cd2ea2a2b570c")),
+        .package(url: "https://github.com/PureSwift/CFontConfig.git", .revision("f47c3ea87307478428df762dc2e181c12643a884")),
+        .package(url: "https://github.com/PureSwift/CFreeType.git", .revision("a8c830218999af31691e154cecae783bae1f0ab9"))
     ],
     targets: [
         .target(


### PR DESCRIPTION
This fork adopts the new `Package.swift` structure of Swift 4.2 and updates the referenced C wrappers to https://github.com/PureSwift/CFreeType/pull/4, https://github.com/PureSwift/CCairo/pull/2 and https://github.com/PureSwift/CFontConfig/pull/2.