### PR TITLE
Expose pointer to enable external extensibility

### DIFF
--- a/Sources/Cairo/Context.swift
+++ b/Sources/Cairo/Context.swift
@@ -14,16 +14,14 @@ public final class Context {
     // MARK: - Properties
     
     public let surface: Surface
-    
-    // MARK: - Internal Properties
-    
-    internal let internalPointer: OpaquePointer
+
+    public let pointer: OpaquePointer
     
     // MARK: - Initialization
     
     deinit {
      
-        cairo_destroy(internalPointer)
+        cairo_destroy(pointer)
     }
     
     /// Creates a new `Context` with all graphics state parameters set to default values 
@@ -31,11 +29,11 @@ public final class Context {
     public init(surface: Surface) {
         
         // create
-        let internalPointer = cairo_create(surface.internalPointer)
+        let pointer = cairo_create(surface.pointer)
         
-        assert(internalPointer != nil, "Could not create internal pointer")
+        assert(pointer != nil, "Could not create internal pointer")
         // set values
-        self.internalPointer = internalPointer!
+        self.pointer = pointer!
         self.surface = surface
     }
     
@@ -47,13 +45,13 @@ public final class Context {
     /// each call to `restore()` restores the state from the matching paired `save()`.
     public func save() {
         
-        cairo_save(internalPointer)
+        cairo_save(pointer)
     }
     
     /// Restores the context to the state saved by a preceding call to `save()` and removes that state from the stack of saved states.
     public func restore() {
         
-        cairo_restore(internalPointer)
+        cairo_restore(pointer)
     }
     
     /// Temporarily redirects drawing to an intermediate surface known as a group. 
@@ -68,11 +66,11 @@ public final class Context {
         
         if let content = content {
             
-            cairo_push_group_with_content(internalPointer, cairo_content_t(content))
+            cairo_push_group_with_content(pointer, cairo_content_t(content))
             
         } else {
             
-            cairo_push_group(internalPointer)
+            cairo_push_group(pointer)
         }
     }
     
@@ -80,7 +78,7 @@ public final class Context {
     /// returns a new pattern containing the results of all drawing operations performed to the group.
     public func popGroup() -> Pattern {
         
-        let patternPointer = cairo_pop_group(internalPointer)!
+        let patternPointer = cairo_pop_group(pointer)!
         
         let pattern = Pattern(patternPointer)
         
@@ -91,17 +89,17 @@ public final class Context {
     /// and installs the resulting pattern as the source pattern in the given context.
     public func popGroupToSource() {
         
-        cairo_pop_group_to_source(internalPointer)
+        cairo_pop_group_to_source(pointer)
     }
     
     public func setSource(color: (red: Double, green: Double, blue: Double)) {
         
-        cairo_set_source_rgb(internalPointer, color.red, color.green, color.blue)
+        cairo_set_source_rgb(pointer, color.red, color.green, color.blue)
     }
     
     public func setSource(color: (red: Double, green: Double, blue: Double, alpha: Double)) {
         
-        cairo_set_source_rgba(internalPointer, color.red, color.green, color.blue, color.alpha)
+        cairo_set_source_rgba(pointer, color.red, color.green, color.blue, color.alpha)
     }
     
     /// A drawing operator that paints the current source using the alpha channel of surface as a mask. 
@@ -109,50 +107,50 @@ public final class Context {
     /// - Note: Opaque areas of `surface` are painted with the source, transparent areas are not painted.
     public func mask(surface: Surface, at point: (x: Double, y: Double)) {
         
-        cairo_mask_surface(internalPointer, surface.internalPointer, point.x, point.y)
+        cairo_mask_surface(pointer, surface.pointer, point.x, point.y)
     }
     
     public func stroke() {
         
-        cairo_stroke(internalPointer)
+        cairo_stroke(pointer)
     }
     
     public func fill() {
         
-        cairo_fill(internalPointer)
+        cairo_fill(pointer)
     }
     
     public func fillPreserve() {
         
-        cairo_fill_preserve(internalPointer)
+        cairo_fill_preserve(pointer)
     }
     
     public func clip() {
         
-        cairo_clip(internalPointer)
+        cairo_clip(pointer)
     }
     
     public func clipPreserve() {
         
-        cairo_clip_preserve(internalPointer)
+        cairo_clip_preserve(pointer)
     }
     
     public func paint(alpha: Double? = nil) {
         
         if let alpha = alpha {
             
-            cairo_paint_with_alpha(internalPointer, alpha)
+            cairo_paint_with_alpha(pointer, alpha)
         }
         else {
             
-            cairo_paint(internalPointer)
+            cairo_paint(pointer)
         }
     }
     
     /// Adds a closed sub-path rectangle of the given size to the current path at position `(x , y)` in user-space coordinates.
     public func addRectangle(x: Double, y: Double, width: Double, height: Double) {
         
-        cairo_rectangle(internalPointer, x, y, width, height)
+        cairo_rectangle(pointer, x, y, width, height)
     }
     
     /// Adds a circular arc of the given radius to the current path. 
@@ -176,18 +174,18 @@ public final class Context {
         
         if negative {
             
-            cairo_arc_negative(internalPointer, center.x, center.y, radius, angle.0, angle.1)
+            cairo_arc_negative(pointer, center.x, center.y, radius, angle.0, angle.1)
             
         } else {
             
-            cairo_arc(internalPointer, center.x, center.y, radius, angle.0, angle.1)
+            cairo_arc(pointer, center.x, center.y, radius, angle.0, angle.1)
         }
     }
     
     /// Creates a copy of the current path and returns it to the user as a `Path`.
     public func copyPath() -> Path {
         
-        let pathPointer = cairo_copy_path(internalPointer)!
+        let pathPointer = cairo_copy_path(pointer)!
         
         return Path(pathPointer)
     }
@@ -195,46 +193,46 @@ public final class Context {
     /// Gets a flattened copy of the current path.
     public func copyFlatPath() -> Path {
         
-        let pathPointer = cairo_copy_path_flat(internalPointer)!
+        let pathPointer = cairo_copy_path_flat(pointer)!
         
         return Path(pathPointer)
     }
     
     public func setFont(size: Double) {
         
-        cairo_set_font_size(internalPointer, size)
+        cairo_set_font_size(pointer, size)
     }
     
     public func setFont(face: (family: String, slant: FontSlant, weight: FontWeight)) {
         
-        cairo_select_font_face(internalPointer, face.family, cairo_font_slant_t(face.slant.rawValue), cairo_font_weight_t(face.weight.rawValue))
+        cairo_select_font_face(pointer, face.family, cairo_font_slant_t(face.slant.rawValue), cairo_font_weight_t(face.weight.rawValue))
     }
     
     public func setFont(matrix: Matrix) {
         
         var copy = matrix
         
-        cairo_set_font_matrix(internalPointer, &copy)
+        cairo_set_font_matrix(pointer, &copy)
     }
     
     public func move(to coordinate: (x: Double, y: Double)) {
         
-        cairo_move_to(internalPointer, coordinate.x, coordinate.y)
+        cairo_move_to(pointer, coordinate.x, coordinate.y)
     }
     
     public func line(to coordinate: (x: Double, y: Double)) {
         
-        cairo_line_to(internalPointer, coordinate.x, coordinate.y)
+        cairo_line_to(pointer, coordinate.x, coordinate.y)
     }
     
     public func curve(to controlPoints: (first: (x: Double, y: Double), second: (x: Double, y: Double), end: (x: Double, y: Double))) {
         
-        cairo_curve_to(internalPointer, controlPoints.first.x, controlPoints.first.y, controlPoints.second.x, controlPoints.second.y, controlPoints.end.x, controlPoints.end.y)
+        cairo_curve_to(pointer, controlPoints.first.x, controlPoints.first.y, controlPoints.second.x, controlPoints.second.y, controlPoints.end.x, controlPoints.end.y)
     }
     
     public func show(text: String) {
         
-        cairo_show_text(internalPointer, text)
+        cairo_show_text(pointer, text)
     }
     
     public func show(glyph: cairo_glyph_t) {
@@ -242,73 +240,73 @@ public final class Context {
         var copy = glyph
         
         // due to bug, better to show one at a time
-        cairo_show_glyphs(internalPointer, &copy, 1)
+        cairo_show_glyphs(pointer, &copy, 1)
     }
     
     public func scale(x: Double, y: Double) {
         
-        cairo_scale(internalPointer, x, y)
+        cairo_scale(pointer, x, y)
     }
     
     public func translate(x: Double, y: Double) {
         
-        cairo_translate(internalPointer, x, y)
+        cairo_translate(pointer, x, y)
     }
     
     public func rotate(_ angle: Double) {
         
-        cairo_rotate(internalPointer, angle)
+        cairo_rotate(pointer, angle)
     }
     
     public func transform(_ matrix: Matrix) {
         
         var copy = matrix
         
-        cairo_transform(internalPointer, &copy)
+        cairo_transform(pointer, &copy)
     }
     
     public func showPage() {
         
-        cairo_show_page(internalPointer)
+        cairo_show_page(pointer)
     }
     
     public func copyPage() {
         
-        cairo_copy_page(internalPointer)
+        cairo_copy_page(pointer)
     }
     
     public func newPath() {
         
-        cairo_new_path(internalPointer)
+        cairo_new_path(pointer)
     }
     
     public func closePath() {
         
-        cairo_close_path(internalPointer)
+        cairo_close_path(pointer)
     }
     
     public func newSubpath() {
         
-        cairo_new_sub_path(internalPointer)
+        cairo_new_sub_path(pointer)
     }
     
     // MARK: - Accessors
     
     public var status: Status {
         
-        return cairo_status(internalPointer)
+        return cairo_status(pointer)
     }
     
     public var currentPoint: (x: Double, y: Double)? {
         
-        guard cairo_has_current_point(internalPointer) != 0
+        guard cairo_has_current_point(pointer) != 0
             else { return nil }
         
         var x: Double = 0
         
         var y: Double = 0
         
-        cairo_get_current_point(internalPointer, &x, &y)
+        cairo_get_current_point(pointer, &x, &y)
         
         return (x: x, y: y)
     }
@@ -317,7 +315,7 @@ public final class Context {
         
         get {
             
-            let patternPointer = cairo_get_source(internalPointer)!
+            let patternPointer = cairo_get_source(pointer)!
             
             cairo_pattern_reference(patternPointer)
             
@@ -326,7 +324,7 @@ public final class Context {
         
         set {
             
-            cairo_set_source(internalPointer, newValue.internalPointer)
+            cairo_set_source(pointer, newValue.pointer)
         }
     }
     
@@ -336,7 +334,7 @@ public final class Context {
             
             var matrix = Matrix()
             
-            cairo_get_matrix(internalPointer, &matrix)
+            cairo_get_matrix(pointer, &matrix)
             
             return matrix
         }
@@ -345,7 +343,7 @@ public final class Context {
             
             var copy = newValue
             
-            cairo_set_matrix(internalPointer, &copy)
+            cairo_set_matrix(pointer, &copy)
         }
     }
     
@@ -355,7 +353,7 @@ public final class Context {
     /// as started by the most recent call to `pushGroup()`.
     public var groupTarget: Surface {
         
-        let surfacePointer = cairo_get_group_target(internalPointer)!
+        let surfacePointer = cairo_get_group_target(pointer)!
         
         let surface = try! Surface(surfacePointer)
         
@@ -364,37 +362,37 @@ public final class Context {
     
     public var fillRule: cairo_fill_rule_t {
         
-        get { return cairo_get_fill_rule(internalPointer) }
+        get { return cairo_get_fill_rule(pointer) }
         
-        set { cairo_set_fill_rule(internalPointer, newValue) }
+        set { cairo_set_fill_rule(pointer, newValue) }
     }
     
     public var antialias: cairo_antialias_t {
         
-        get { return cairo_get_antialias(internalPointer) }
+        get { return cairo_get_antialias(pointer) }
         
-        set { cairo_set_antialias(internalPointer, newValue) }
+        set { cairo_set_antialias(pointer, newValue) }
     }
     
     public var lineWidth: Double {
         
-        get { return cairo_get_line_width(internalPointer) }
+        get { return cairo_get_line_width(pointer) }
         
-        set { cairo_set_line_width(internalPointer, newValue) }
+        set { cairo_set_line_width(pointer, newValue) }
     }
     
     public var lineJoin: cairo_line_join_t {
         
-        get { return cairo_get_line_join(internalPointer) }
+        get { return cairo_get_line_join(pointer) }
         
-        set { cairo_set_line_join(internalPointer, newValue) }
+        set { cairo_set_line_join(pointer, newValue) }
     }
     
     public var lineCap: cairo_line_cap_t {
         
-        get { return cairo_get_line_cap(internalPointer) }
+        get { return cairo_get_line_cap(pointer) }
         
-        set { cairo_set_line_cap(internalPointer, newValue) }
+        set { cairo_set_line_cap(pointer, newValue) }
     }
     
     public var lineDash: (phase: Double, lengths: [Double]) {
@@ -403,11 +401,11 @@ public final class Context {
             
             var phase: Double = 0
             
-            let dashCount = Int(cairo_get_dash_count(internalPointer))
+            let dashCount = Int(cairo_get_dash_count(pointer))
             
             var lengths = [Double](repeating: 0, count: dashCount)
             
-            cairo_get_dash(internalPointer, &lengths, &phase)
+            cairo_get_dash(pointer, &lengths, &phase)
             
             return (phase: phase, lengths: lengths)
         }
@@ -416,22 +414,22 @@ public final class Context {
             
             var lengthsCopy = newValue.lengths
             
-            cairo_set_dash(internalPointer, &lengthsCopy, Int32(newValue.lengths.count), newValue.phase)
+            cairo_set_dash(pointer, &lengthsCopy, Int32(newValue.lengths.count), newValue.phase)
         }
     }
     
     public var miterLimit: Double {
         
-        get { return cairo_get_miter_limit(internalPointer) }
+        get { return cairo_get_miter_limit(pointer) }
         
-        set { cairo_set_miter_limit(internalPointer, newValue) }
+        set { cairo_set_miter_limit(pointer, newValue) }
     }
     
     public var tolerance: Double {
         
-        get { return cairo_get_tolerance(internalPointer) }
+        get { return cairo_get_tolerance(pointer) }
         
-        set { cairo_set_tolerance(internalPointer, newValue) }
+        set { cairo_set_tolerance(pointer, newValue) }
     }
     
     public var pathExtents: (x: Double, y: Double, width: Double, height: Double) {
@@ -441,16 +439,16 @@ public final class Context {
         var width: Double = 0
         var height: Double = 0
         
-        cairo_path_extents(internalPointer, &x, &y, &width, &height)
+        cairo_path_extents(pointer, &x, &y, &width, &height)
         
         return (x: x, y: y, width: width, height: height)
     }
     
     public var `operator`: cairo_operator_t {
         
-        get { return cairo_get_operator(internalPointer) }
+        get { return cairo_get_operator(pointer) }
         
-        set { cairo_set_operator(internalPointer, newValue) }
+        set { cairo_set_operator(pointer, newValue) }
     }
     
     public var fontFace: FontFace {
@@ -459,7 +457,7 @@ public final class Context {
             
             // This function never returns NULL. 
             // If memory cannot be allocated, a special "nil" `cairo_font_face_t` object will be returned
-            let fontFacePointer = cairo_get_font_face(internalPointer)!
+            let fontFacePointer = cairo_get_font_face(pointer)!
             
             guard cairo_font_face_status(fontFacePointer) != CAIRO_STATUS_NO_MEMORY
                 else { fatalError("Memory cannot be allocated") }
@@ -470,7 +468,7 @@ public final class Context {
             return FontFace(fontFacePointer)
         }
         
-        set { cairo_set_font_face(internalPointer, newValue.internalPointer) }
+        set { cairo_set_font_face(pointer, newValue.pointer) }
     }
     
     public var scaledFont: ScaledFont {
@@ -479,7 +477,7 @@ public final class Context {
             
             // This function never returns NULL.
             // If memory cannot be allocated, a special "nil" `cairo_scaled_font_t` object will be returned
-            let scaledFontPointer = cairo_get_scaled_font(internalPointer)!
+            let scaledFontPointer = cairo_get_scaled_font(pointer)!
             
             guard cairo_scaled_font_status(scaledFontPointer) != CAIRO_STATUS_NO_MEMORY
                 else { fatalError("Memory cannot be allocated") }
@@ -490,6 +488,6 @@ public final class Context {
             return ScaledFont(scaledFontPointer)
         }
         
-        set { cairo_set_scaled_font(internalPointer, newValue.internalPointer) }
+        set { cairo_set_scaled_font(pointer, newValue.pointer) }
     }
 }

--- a/Sources/Cairo/Font.swift
+++ b/Sources/Cairo/Font.swift
@@ -14,25 +14,25 @@ public final class ScaledFont {
     
     // MARK: - Properties
     
-    internal let internalPointer: OpaquePointer
+    public let pointer: OpaquePointer
     
     // MARK: - Initialization
     
     deinit {
         
-        cairo_scaled_font_destroy(internalPointer)
+        cairo_scaled_font_destroy(pointer)
     }
     
-    internal init(_ internalPointer: OpaquePointer) {
+    internal init(_ pointer: OpaquePointer) {
         
-        self.internalPointer = internalPointer
+        self.pointer = pointer
     }
     
     public init(face: FontFace, matrix: Matrix, currentTransformation: Matrix, options: FontOptions) {
         
         var matrixCopy = (matrix, currentTransformation)
         
-        self.internalPointer = cairo_scaled_font_create(face.internalPointer, &matrixCopy.0, &matrixCopy.1, options.internalPointer)!
+        self.pointer = cairo_scaled_font_create(face.pointer, &matrixCopy.0, &matrixCopy.1, options.pointer)!
         
         guard self.status != CAIRO_STATUS_NO_MEMORY
             else { fatalError("Out of memory") }
@@ -42,17 +42,17 @@ public final class ScaledFont {
     
     public var status: Status {
         
-        return cairo_scaled_font_status(internalPointer)
+        return cairo_scaled_font_status(pointer)
     }
     
     public lazy var type: cairo_font_type_t = {
         
-        return cairo_scaled_font_get_type(self.internalPointer)
+        return cairo_scaled_font_get_type(self.pointer)
     }()
     
     public lazy var face: FontFace = {
         
-        let pointer = cairo_scaled_font_get_font_face(self.internalPointer)!
+        let pointer = cairo_scaled_font_get_font_face(self.pointer)!
         
         cairo_font_face_reference(pointer)
         
@@ -64,7 +64,7 @@ public final class ScaledFont {
         
         var fontExtents = cairo_font_extents_t()
         
-        cairo_scaled_font_extents(internalPointer, &fontExtents)
+        cairo_scaled_font_extents(pointer, &fontExtents)
         
         return fontExtents
     }
@@ -246,9 +246,9 @@ public final class ScaledFont {
     
     private func lockFontFace<T>(_ block: (FT_Face) -> T) -> T {
         
-        let ftFace = cairo_ft_scaled_font_lock_face(self.internalPointer)!
+        let ftFace = cairo_ft_scaled_font_lock_face(self.pointer)!
         
-        defer { cairo_ft_scaled_font_unlock_face(self.internalPointer) }
+        defer { cairo_ft_scaled_font_unlock_face(self.pointer) }
         
         return block(ftFace)
     }
@@ -265,104 +265,104 @@ public final class FontFace {
     
     // MARK: - Properties
     
-    internal let internalPointer: OpaquePointer
+    internal let pointer: OpaquePointer
     
     // MARK: - Initialization
     
     deinit {
         
-        cairo_font_face_destroy(internalPointer)
+        cairo_font_face_destroy(pointer)
     }
     
     public init(fontConfigPattern: OpaquePointer) {
         
-        self.internalPointer = cairo_ft_font_face_create_for_pattern(fontConfigPattern)!
+        self.pointer = cairo_ft_font_face_create_for_pattern(fontConfigPattern)!
     }
     
-    internal init(_ internalPointer: OpaquePointer) {
+    internal init(_ pointer: OpaquePointer) {
         
-        self.internalPointer = internalPointer
+        self.pointer = pointer
     }
     
     // MARK: - Accessors
     
     public var status: Status {
         
-        return cairo_font_face_status(internalPointer)
+        return cairo_font_face_status(pointer)
     }
     
-    public lazy var type: cairo_font_type_t = cairo_font_face_get_type(self.internalPointer) // Never changes
+    public lazy var type: cairo_font_type_t = cairo_font_face_get_type(self.pointer) // Never changes
 }
 
 public final class FontOptions {
     
     // MARK: - Properties
     
-    internal let internalPointer: OpaquePointer
+    internal let pointer: OpaquePointer
     
     // MARK: - Initialization
     
     deinit {
         
-        cairo_font_options_destroy(internalPointer)
+        cairo_font_options_destroy(pointer)
     }
     
-    internal init(_ internalPointer: OpaquePointer) {
+    internal init(_ pointer: OpaquePointer) {
         
-        self.internalPointer = internalPointer
+        self.pointer = pointer
     }
     
     /// Initializes a new `FontOptions` object.
     public init() {
         
-        self.internalPointer = cairo_font_options_create()!
+        self.pointer = cairo_font_options_create()!
     }
     
     // MARK: - Methods
     
     public func merge(_ other: FontOptions) {
         
-        cairo_font_options_merge(internalPointer, other.internalPointer)
+        cairo_font_options_merge(pointer, other.pointer)
     }
     
     // MARK: - Accessors
     
     public var status: Status {
         
-        return cairo_font_options_status(internalPointer)
+        return cairo_font_options_status(pointer)
     }
     
     public var copy: FontOptions {
         
-        return FontOptions(cairo_font_options_copy(internalPointer))
+        return FontOptions(cairo_font_options_copy(pointer))
     }
     
     public var hintMetrics: FontHintMetrics {
         
-        get { return FontHintMetrics(rawValue: cairo_font_options_get_hint_metrics(internalPointer).rawValue)! }
+        get { return FontHintMetrics(rawValue: cairo_font_options_get_hint_metrics(pointer).rawValue)! }
         
-        set { cairo_font_options_set_hint_metrics(internalPointer, cairo_hint_metrics_t(rawValue: newValue.rawValue)) }
+        set { cairo_font_options_set_hint_metrics(pointer, cairo_hint_metrics_t(rawValue: newValue.rawValue)) }
     }
     
     public var hintStyle: cairo_hint_style_t {
         
-        get { return cairo_font_options_get_hint_style(internalPointer) }
+        get { return cairo_font_options_get_hint_style(pointer) }
         
-        set { cairo_font_options_set_hint_style(internalPointer, newValue) }
+        set { cairo_font_options_set_hint_style(pointer, newValue) }
     }
     
     public var antialias: cairo_antialias_t {
         
-        get { return cairo_font_options_get_antialias(internalPointer) }
+        get { return cairo_font_options_get_antialias(pointer) }
         
-        set { cairo_font_options_set_antialias(internalPointer, newValue) }
+        set { cairo_font_options_set_antialias(pointer, newValue) }
     }
     
     public var subpixelOrder: cairo_subpixel_order_t {
         
-        get { return cairo_font_options_get_subpixel_order(internalPointer) }
+        get { return cairo_font_options_get_subpixel_order(pointer) }
         
-        set { cairo_font_options_set_subpixel_order(internalPointer, newValue) }
+        set { cairo_font_options_set_subpixel_order(pointer, newValue) }
     }
 }
 
@@ -370,7 +370,7 @@ extension FontOptions: Equatable {
     
     public static func == (lhs: FontOptions, rhs: FontOptions) -> Bool {
         
-        return cairo_font_options_equal(lhs.internalPointer, rhs.internalPointer) != 0
+        return cairo_font_options_equal(lhs.pointer, rhs.pointer) != 0
     }
 }
 
@@ -378,7 +378,7 @@ extension FontOptions: Hashable {
     
     public func hash(into hasher: inout Hasher) {
         
-        let hashValue = cairo_font_options_hash(internalPointer)
+        let hashValue = cairo_font_options_hash(pointer)
         hashValue.hash(into: &hasher)
     }
 }

--- a/Sources/Cairo/Path.swift
+++ b/Sources/Cairo/Path.swift
@@ -10,32 +10,32 @@ import CCairo
 
 public final class Path {
     
-    // MARK: - Internal Properties
+    // MARK: - Properties
     
-    internal let internalPointer: UnsafeMutablePointer<cairo_path_t>
+    public let pointer: UnsafeMutablePointer<cairo_path_t>
     
     // MARK: - Initialization
     
     deinit {
         
-        cairo_path_destroy(internalPointer)
+        cairo_path_destroy(pointer)
     }
     
-    internal init(_ internalPointer: UnsafeMutablePointer<cairo_path_t>) {
+    internal init(_ pointer: UnsafeMutablePointer<cairo_path_t>) {
         
-        self.internalPointer = internalPointer
+        self.pointer = pointer
     }
     
     // MARK: - Properties
     
     public var count: Int {
         
-        return Int(internalPointer.pointee.num_data)
+        return Int(pointer.pointee.num_data)
     }
     
     public var status: Status {
         
-        return internalPointer.pointee.status
+        return pointer.pointee.status
     }
     
     public lazy var data: [cairo_path_data_t] = {
@@ -44,7 +44,7 @@ public final class Path {
         
         for index in 0 ..< self.count {
             
-            data[index] = self.internalPointer.pointee.data[index]
+            data[index] = self.pointer.pointee.data[index]
         }
         
         return data
@@ -54,6 +54,6 @@ public final class Path {
     
     public subscript (index: Int) -> cairo_path_data_t {
         
-        return internalPointer.pointee.data[index]
+        return pointer.pointee.data[index]
     }
 }

--- a/Sources/Cairo/Pattern.swift
+++ b/Sources/Cairo/Pattern.swift
@@ -13,59 +13,59 @@ import CCairo
 /// There are different subtypes of patterns, for different types of sources.
 public final class Pattern {
     
-    // MARK: - Internal Properties
+    // MARK: - Properties
     
-    internal var internalPointer: OpaquePointer
+    public var pointer: OpaquePointer
     
     // MARK: - Initialization
     
     deinit {
         
-        cairo_pattern_destroy(internalPointer)
+        cairo_pattern_destroy(pointer)
     }
     
-    internal init(_ internalPointer: OpaquePointer) {
+    internal init(_ pointer: OpaquePointer) {
         
-        self.internalPointer = internalPointer
+        self.pointer = pointer
     }
     
     public init(surface: Surface) {
         
-        self.internalPointer = cairo_pattern_create_for_surface(surface.internalPointer)
+        self.pointer = cairo_pattern_create_for_surface(surface.pointer)
     }
     
     public init(color: (red: Double, green: Double, blue: Double)) {
         
-        self.internalPointer = cairo_pattern_create_rgb(color.red, color.green, color.blue)
+        self.pointer = cairo_pattern_create_rgb(color.red, color.green, color.blue)
     }
     
     public init(color: (red: Double, green: Double, blue: Double, alpha: Double)) {
         
-        self.internalPointer = cairo_pattern_create_rgba(color.red, color.green, color.blue, color.alpha)
+        self.pointer = cairo_pattern_create_rgba(color.red, color.green, color.blue, color.alpha)
     }
     
     public init(linear: (origin: (x: Double, y: Double), destination: (x: Double, y: Double))) {
         
-        self.internalPointer = cairo_pattern_create_linear(linear.origin.x, linear.origin.y, linear.destination.x, linear.destination.y)
+        self.pointer = cairo_pattern_create_linear(linear.origin.x, linear.origin.y, linear.destination.x, linear.destination.y)
     }
     
     public init(radial: (start: (center: (x: Double, y: Double), radius: Double), end: (center: (x: Double, y: Double), radius: Double))) {
         
-        self.internalPointer = cairo_pattern_create_radial(radial.start.center.x, radial.start.center.y, radial.start.radius, radial.end.center.x, radial.end.center.y, radial.end.radius)
+        self.pointer = cairo_pattern_create_radial(radial.start.center.x, radial.start.center.y, radial.start.radius, radial.end.center.x, radial.end.center.y, radial.end.radius)
     }
     
     public static var mesh: Pattern {
         
-        let internalPointer = cairo_pattern_create_mesh()!
+        let pointer = cairo_pattern_create_mesh()!
         
-        return self.init(internalPointer)
+        return self.init(pointer)
     }
     
     // MARK: - Accessors
     
     public var type: PatternType {
         
-        let internalPattern = cairo_pattern_get_type(internalPointer)
+        let internalPattern = cairo_pattern_get_type(pointer)
         
         let pattern = PatternType(rawValue: internalPattern.rawValue)!
         
@@ -74,7 +74,7 @@ public final class Pattern {
     
     public var status: Status {
         
-        return cairo_pattern_status(internalPointer)
+        return cairo_pattern_status(pointer)
     }
     
     public var matrix: Matrix {
@@ -83,7 +83,7 @@ public final class Pattern {
             
             var matrix = Matrix()
             
-            cairo_pattern_get_matrix(internalPointer, &matrix)
+            cairo_pattern_get_matrix(pointer, &matrix)
             
             return matrix
         }
@@ -92,15 +92,15 @@ public final class Pattern {
             
             var newValue = newValue
             
-            cairo_pattern_set_matrix(internalPointer, &newValue)
+            cairo_pattern_set_matrix(pointer, &newValue)
         }
     }
     
     public var extend: Extend {
         
-        get { return Extend(rawValue: cairo_pattern_get_extend(internalPointer).rawValue)!  }
+        get { return Extend(rawValue: cairo_pattern_get_extend(pointer).rawValue)!  }
         
-        set { cairo_pattern_set_extend(internalPointer, cairo_extend_t(rawValue: newValue.rawValue)) }
+        set { cairo_pattern_set_extend(pointer, cairo_extend_t(rawValue: newValue.rawValue)) }
     }
     
     // MARK: - Methods
@@ -108,13 +108,13 @@ public final class Pattern {
     /// Adds an opaque color stop to a gradient pattern.
     public func addColorStop(_ offset: Double, red: Double, green: Double, blue: Double) {
         
-        cairo_pattern_add_color_stop_rgb(internalPointer, offset, red, green, blue)
+        cairo_pattern_add_color_stop_rgb(pointer, offset, red, green, blue)
     }
     
     /// Adds an opaque color stop to a gradient pattern.
     public func addColorStop(_ offset: Double, red: Double, green: Double, blue: Double, alpha: Double) {
         
-        cairo_pattern_add_color_stop_rgba(internalPointer, offset, red, green, blue, alpha)
+        cairo_pattern_add_color_stop_rgba(pointer, offset, red, green, blue, alpha)
     }
 }
 

--- a/Sources/Cairo/Surface.swift
+++ b/Sources/Cairo/Surface.swift
@@ -10,22 +10,22 @@ import CCairo
 
 public class Surface {
     
-    // MARK: - Internal Properties
+    // MARK: - Properties
     
-    internal let internalPointer: OpaquePointer
+    public let pointer: OpaquePointer
     
     // MARK: - Initialization
     
     deinit {
         
-        cairo_surface_destroy(internalPointer)
+        cairo_surface_destroy(pointer)
     }
     
-    internal init(_ internalPointer: OpaquePointer) throws {
+    internal init(_ pointer: OpaquePointer) throws {
         
-        try cairo_surface_create_check_status(internalPointer)
+        try cairo_surface_create_check_status(pointer)
         
-        self.internalPointer = internalPointer
+        self.pointer = pointer
     }
     
     // MARK: - Class Methods
@@ -46,7 +46,7 @@ public class Surface {
     /// If the surface doesn't support direct access, then this function does nothing.
     public final func flush() {
         
-        cairo_surface_flush(internalPointer)
+        cairo_surface_flush(pointer)
     }
     
     /// Tells cairo that drawing has been done to surface using means other than cairo, 
@@ -55,32 +55,32 @@ public class Surface {
     /// - Note: You must `Cairo.Surface.flush()` before doing such drawing.
     public final func markDirty() {
         
-        cairo_surface_mark_dirty(internalPointer)
+        cairo_surface_mark_dirty(pointer)
     }
     
     /// This function finishes the surface and drops all references to external resources.
     public final func finish() {
         
-        cairo_surface_finish(internalPointer)
+        cairo_surface_finish(pointer)
     }
     
     // MARK: - Accessors
     
     public final var type: SurfaceType {
         
-        return SurfaceType(cairo_surface_get_type(internalPointer))
+        return SurfaceType(cairo_surface_get_type(pointer))
     }
     
     /// The content type which indicates whether the surface contains color and/or alpha information
     public final var content: Content {
         
-        return Content(cairo_surface_get_content(internalPointer))
+        return Content(cairo_surface_get_content(pointer))
     }
     
     /// Checks whether an error has previously occurred for this surface.
     public final var status: Status {
         
-        return cairo_surface_status(internalPointer)
+        return cairo_surface_status(pointer)
     }
 }
 
@@ -88,12 +88,12 @@ public class Surface {
 
 /// Used to check if the surface has an error
 @inline(__always)
-internal func cairo_surface_create_check_status(_ internalPointer: OpaquePointer) throws {
+internal func cairo_surface_create_check_status(_ pointer: OpaquePointer) throws {
     
     // check status
-    if let error = CairoError(rawValue: cairo_surface_status(internalPointer).rawValue) {
+    if let error = CairoError(rawValue: cairo_surface_status(pointer).rawValue) {
         
-        cairo_surface_destroy(internalPointer)
+        cairo_surface_destroy(pointer)
         
         throw error
     }

--- a/Sources/Cairo/SurfacePDF.swift
+++ b/Sources/Cairo/SurfacePDF.swift
@@ -16,9 +16,9 @@ public extension Surface {
         
         public init(filename: String, width: Double, height: Double) throws {
             
-            let internalPointer = cairo_pdf_surface_create(filename, width, height)!
+            let pointer = cairo_pdf_surface_create(filename, width, height)!
             
-            try super.init(internalPointer)
+            try super.init(pointer)
         }
         
         // MARK: - Class Methods

--- a/Sources/Cairo/SurfacePNG.swift
+++ b/Sources/Cairo/SurfacePNG.swift
@@ -14,7 +14,7 @@ public extension Surface {
     /// Writes the surface's contents to a PNG file.
     func writePNG(atPath path: String) {
         
-        cairo_surface_write_to_png(internalPointer, path)
+        cairo_surface_write_to_png(pointer, path)
     }
     
     func writePNG() throws -> Data {
@@ -23,9 +23,9 @@ public extension Surface {
         
         let unmanaged = Unmanaged.passUnretained(dataProvider)
         
-        let pointer = unmanaged.toOpaque()
+        let dataPointer = unmanaged.toOpaque()
         
-        if let error = cairo_surface_write_to_png_stream(internalPointer, pngWrite, pointer).toError() {
+        if let error = cairo_surface_write_to_png_stream(pointer, pngWrite, dataPointer).toError() {
             
             throw error
         }
@@ -40,9 +40,9 @@ public extension Surface.Image {
     @inline(__always)
     private convenience init(png readFunction: @escaping cairo_read_func_t, closure: UnsafeMutableRawPointer) throws {
         
-        let internalPointer = cairo_image_surface_create_from_png_stream(readFunction, closure)!
+        let pointer = cairo_image_surface_create_from_png_stream(readFunction, closure)!
         
-        try self.init(internalPointer)
+        try self.init(pointer)
     }
     
     convenience init(png data: Data) throws {

--- a/Sources/Cairo/SurfaceSVG.swift
+++ b/Sources/Cairo/SurfaceSVG.swift
@@ -16,9 +16,9 @@ public extension Surface {
         
         public init(filename: String, width: Double, height: Double) throws {
             
-            let internalPointer = cairo_svg_surface_create(filename, width, height)!
+            let pointer = cairo_svg_surface_create(filename, width, height)!
             
-            try super.init(internalPointer)
+            try super.init(pointer)
         }
         
         // MARK: - Class Methods


### PR DESCRIPTION
This allows external modules to create extensions and add Swift wrappers for functionality not provided by the Cairo library.