### PR TITLE
Expose opaque pointers to enable external extensibility

### DIFF
--- a/Sources/Cairo/Context.swift
+++ b/Sources/Cairo/Context.swift
@@ -9,7 +9,7 @@
 import CCairo
 
 /// Cairo Context
-public final class Context {
+public final class Context: OpaquePointerOwner {
     
     // MARK: - Properties
     

--- a/Sources/Cairo/Font.swift
+++ b/Sources/Cairo/Font.swift
@@ -10,7 +10,7 @@ import CCairo
 import CFontConfig
 import CFreeType
 
-public final class ScaledFont {
+public final class ScaledFont: OpaquePointerOwner {
     
     // MARK: - Properties
     
@@ -261,7 +261,7 @@ public typealias FontIndex = UInt16
 /// The font's face.
 ///
 /// - Note: Only compatible with FreeType and FontConfig.
-public final class FontFace {
+public final class FontFace: OpaquePointerOwner {
     
     // MARK: - Properties
     
@@ -294,7 +294,7 @@ public final class FontFace {
     public lazy var type: cairo_font_type_t = cairo_font_face_get_type(self.internalPointer) // Never changes
 }
 
-public final class FontOptions {
+public final class FontOptions: OpaquePointerOwner {
     
     // MARK: - Properties
     

--- a/Sources/Cairo/OpaquePointerProvider.swift
+++ b/Sources/Cairo/OpaquePointerProvider.swift
@@ -1,0 +1,36 @@
+//
+//  OpaquePointerProvider.swift
+//  Cairo
+//
+//  Created by Rayman Rosevear on 2023/05/16.
+//  Copyright © 2023 PureSwift. All rights reserved.
+//
+
+/// This file adds methods providing some extensibility to the library, giving access to the `OpaquePointer`s to the
+/// underlying Cairo opaque struct pointers.
+
+public protocol OpaquePointerProvider {
+
+    /// Calls the given closure with the underlying `OpaquePointer`.
+    ///
+    /// The pointer passed as an argument to `body` is valid only during the execution of `withUnsafeOpaquePointer(_:)`.
+    /// Do not store or return the pointer for later use.
+    ///
+    /// - Parameters:
+    ///   - body: A closure with an opaque pointer parameter. If `body` has a return value, that value is also used as
+    ///     the return value for the `withUnsafeOpaquePointer(_:)` method. The pointer argument is valid only for the
+    ///     duration of the method's execution.
+    /// - Returns: The return value, if any, of the `body` closure parameter.
+    func withUnsafeOpaquePointer<Result>(_ body: (OpaquePointer) throws -> Result) rethrows -> Result
+}
+
+/// Internally conform to this protocol to automatically become an `OpaquePointerProvider`.
+internal protocol OpaquePointerOwner: OpaquePointerProvider {
+    var internalPointer: OpaquePointer { get }
+}
+
+extension OpaquePointerOwner {
+    public func withUnsafeOpaquePointer<Result>(_ body: (OpaquePointer) throws -> Result) rethrows -> Result {
+        try body(self.internalPointer)
+    }
+}

--- a/Sources/Cairo/Pattern.swift
+++ b/Sources/Cairo/Pattern.swift
@@ -11,7 +11,7 @@ import CCairo
 /// Represents a source when drawing onto a surface. 
 ///
 /// There are different subtypes of patterns, for different types of sources.
-public final class Pattern {
+public final class Pattern: OpaquePointerOwner {
     
     // MARK: - Internal Properties
     

--- a/Sources/Cairo/Surface.swift
+++ b/Sources/Cairo/Surface.swift
@@ -8,7 +8,7 @@
 
 import CCairo
 
-public class Surface {
+public class Surface: OpaquePointerOwner {
     
     // MARK: - Internal Properties
     


### PR DESCRIPTION
Based off the conversation in pull request #6, this add support for accessing the underlying opaque pointers.